### PR TITLE
Remove README TODOs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,57 @@
+PATH
+  remote: .
+  specs:
+    rspec-big-split (0.3.3)
+      rspec-core (~> 3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    json (2.12.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    minitest (5.25.5)
+    parallel (1.27.0)
+    parser (3.3.8.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.3.0)
+    regexp_parser (2.10.0)
+    rspec-core (3.13.4)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    rubocop (1.76.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.45.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.45.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  minitest (~> 5.0)
+  rake (~> 13.0)
+  rspec-big-split!
+  rubocop (~> 1.7)
+
+BUNDLED WITH
+   2.6.7

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Rspec::Big::Split
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/rspec/big/split`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Split one big RSpec test file into many smaller ones for parallel execution.
 
 ## Installation
 
@@ -27,6 +25,3 @@ bundle add rspec-big-split
  * You can use `--add-one-on-test-node-index` to modify the index of the test node. This is useful when your CI starts indexing from `0` and you want to start from `1`.
 
 
-## Example project
-
-TODO: Add link to example project

--- a/adr/0001-remove-placeholder-text.md
+++ b/adr/0001-remove-placeholder-text.md
@@ -1,0 +1,15 @@
+# 0001. Remove placeholder text from README
+
+Date: 2025-06-05
+
+## Status
+Accepted
+
+## Context
+The README contained placeholder paragraphs from the gem template, including a TODO paragraph and a reference to an example project link that did not exist. These placeholders did not provide value and could confuse users.
+
+## Decision
+We removed the introductory TODO paragraph and the todo line under the Example project section. The Example project heading was also removed since no content remained.
+
+## Consequences
+The README now begins with a brief description of the gem followed by installation instructions. Documentation reads more smoothly without temporary placeholders.


### PR DESCRIPTION
## Summary
- drop the gem template placeholder paragraph
- remove the empty example project section
- add brief gem description at the top
- record architectural decision about cleaning the README

## Testing
- `bundle exec rake` *(fails: uninitialized constant RSpec)*
- `bundle exec rubocop` *(fails: 3 offenses detected)*

------
https://chatgpt.com/codex/tasks/task_e_6841eec2973c8331a8470fb76b8a2a1f