### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/docs/adr/0001-fix-rubocop-offenses.md
+++ b/docs/adr/0001-fix-rubocop-offenses.md
@@ -1,0 +1,18 @@
+# 1. Fix RuboCop offenses
+
+Date: 2025-06-05
+
+## Status
+Accepted
+
+## Context
+Rubocop detected style offenses preventing clean builds. The gemspec also required a Ruby version lower than our Rubocop TargetRubyVersion.
+
+## Decision
+- Update the gemspec to require Ruby >= 2.4 to match Rubocop configuration.
+- Split a long warning line in the executable for better readability and to satisfy Rubocop's LineLength cop.
+- Document the custom formatter with a brief comment and require `rspec/core` explicitly.
+
+## Consequences
+- Codebase is RuboCop clean under default configuration.
+- Documentation now clarifies purpose of custom formatter.

--- a/exe/rspec-big-split
+++ b/exe/rspec-big-split
@@ -39,7 +39,10 @@ if ARGV[0]
       example_paths[example]
     )
   end
-  warn "Suggesting #{examples_to_run_for_current_worker.size}/#{example_paths.size} examples on worker #{this_worker_index}"
+  warn(
+    "Suggesting #{examples_to_run_for_current_worker.size}/" \
+    "#{example_paths.size} examples on worker #{this_worker_index}"
+  )
   $stdout.puts examples_to_run_for_current_worker
 else
   warn "Usage: rspec-big-split <path to JSON file>"

--- a/lib/rspec/big/split/formatter.rb
+++ b/lib/rspec/big/split/formatter.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require "rspec/core"
 require "rspec/core/formatters/json_formatter"
 
 module Rspec
   module Big
     module Split
+      # Formatter outputs JSON with extra metadata used by rspec-big-split.
       class Formatter < ::RSpec::Core::Formatters::JsonFormatter
         ::RSpec::Core::Formatters.register self
 

--- a/rspec-big-split.gemspec
+++ b/rspec-big-split.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Split one big RSpec test file into many smaller ones for parallel execution"
   spec.homepage      = "https://github.com/ipepe-oss/rspec-big-split"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.1.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
## Summary
- comply with RuboCop line length rules
- document custom formatter and require `rspec/core`
- match rubocop's TargetRubyVersion in gemspec
- document the decision in an ADR

## Testing
- `bundle exec rubocop`
- `bundle exec rake test` *(fails: Expected false to be truthy)*

------
https://chatgpt.com/codex/tasks/task_e_6841f35f07988331a9f571ff65edfe31